### PR TITLE
Regoranize azure outputs to align with configuration sequence.

### DIFF
--- a/azure/dns.tf
+++ b/azure/dns.tf
@@ -2,7 +2,7 @@ data "azurerm_dns_zone" "hosted" {
   name = var.hosted_zone
 }
 
-resource "azurerm_dns_a_record" "opsmanager" {
+resource "azurerm_dns_a_record" "ops-manager" {
   name                = "opsmanager.${var.environment_name}"
   zone_name           = data.azurerm_dns_zone.hosted.name
   resource_group_name = data.azurerm_dns_zone.hosted.resource_group_name

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -39,11 +39,11 @@ locals {
     mysql_lb_name = azurerm_lb.mysql.name
     tcp_lb_name   = azurerm_lb.tcp.name
 
-    apps_dns  = "${azurerm_dns_a_record.apps.name}.${azurerm_dns_a_record.apps.zone_name}"
-    ssh_dns   = "${azurerm_dns_a_record.ssh.name}.${azurerm_dns_a_record.ssh.zone_name}"
-    sys_dns   = "${azurerm_dns_a_record.sys.name}.${azurerm_dns_a_record.sys.zone_name}"
-    tcp_dns   = "${azurerm_dns_a_record.tcp.name}.${azurerm_dns_a_record.tcp.zone_name}"
-    mysql_dns = "${azurerm_dns_a_record.mysql.name}.${azurerm_dns_a_record.mysql.zone_name}"
+    apps_dns_domain = "${replace(azurerm_dns_a_record.apps.name, "*.", "")}.${azurerm_dns_a_record.apps.zone_name}"
+    sys_dns_domain  = "${replace(azurerm_dns_a_record.sys.name, "*.", "")}.${azurerm_dns_a_record.sys.zone_name}"
+    ssh_dns         = "${azurerm_dns_a_record.ssh.name}.${azurerm_dns_a_record.ssh.zone_name}"
+    tcp_dns         = "${azurerm_dns_a_record.tcp.name}.${azurerm_dns_a_record.tcp.zone_name}"
+    mysql_dns       = "${azurerm_dns_a_record.mysql.name}.${azurerm_dns_a_record.mysql.zone_name}"
 
     pks_as_name                                = azurerm_availability_set.pks_as.name
     pks_lb_name                                = azurerm_lb.pks.name

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -13,13 +13,13 @@ locals {
 
     bosh_storage_account_name = azurerm_storage_account.bosh.name
 
-    opsmanager_security_group_name  = azurerm_network_security_group.ops-manager.name
-    opsmanager_private_key          = tls_private_key.ops_manager.private_key_pem
-    opsmanager_public_key           = tls_private_key.ops_manager.public_key_openssh
-    opsmanager_public_ip            = azurerm_public_ip.ops-manager.ip_address
-    opsmanager_container_name       = azurerm_storage_container.ops-manager.name
-    opsmanager_dns                  = "${azurerm_dns_a_record.opsmanager.name}.${azurerm_dns_a_record.opsmanager.zone_name}"
-    opsmanager_storage_account_name = azurerm_storage_account.ops-manager.name
+    ops_manager_security_group_name  = azurerm_network_security_group.ops-manager.name
+    ops_manager_private_key          = tls_private_key.ops_manager.private_key_pem
+    ops_manager_public_key           = tls_private_key.ops_manager.public_key_openssh
+    ops_manager_public_ip            = azurerm_public_ip.ops-manager.ip_address
+    ops_manager_container_name       = azurerm_storage_container.ops-manager.name
+    ops_manager_dns                  = "${azurerm_dns_a_record.ops-manager.name}.${azurerm_dns_a_record.ops-manager.zone_name}"
+    ops_manager_storage_account_name = azurerm_storage_account.ops-manager.name
 
     platform_vms_security_group_name = azurerm_network_security_group.platform-vms.name
 

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -3,69 +3,65 @@ locals {
     location         = var.location
     environment_name = var.environment_name
 
-    network             = azurerm_virtual_network.platform.name
+    network_name        = azurerm_virtual_network.platform.name
     resource_group_name = azurerm_resource_group.platform.name
 
-    security_group_platform_vms_name = azurerm_network_security_group.platform-vms.name
-    security_group_opsmanager_name   = azurerm_network_security_group.ops-manager.name
-    security_group_pks_api_name      = azurerm_network_security_group.pks-api.name
-    security_group_pks_internal_name = azurerm_network_security_group.pks-internal.name
-    security_group_pks_master_name   = azurerm_network_security_group.pks-master.name
+    management_subnet_name    = azurerm_subnet.management.name
+    management_subnet_id      = azurerm_subnet.management.id
+    management_subnet_cidr    = azurerm_subnet.management.address_prefix
+    management_subnet_gateway = cidrhost(azurerm_subnet.management.address_prefix, 1)
 
-    application_security_group_pks_api_name    = azurerm_application_security_group.pks-api.name
-    application_security_group_pks_master_name = azurerm_application_security_group.pks-master.name
+    bosh_storage_account_name = azurerm_storage_account.bosh.name
 
-    opsmanager_private_key = tls_private_key.ops_manager.private_key_pem
-    opsmanager_public_key  = tls_private_key.ops_manager.public_key_openssh
-    opsmanager_public_ip   = azurerm_public_ip.ops-manager.ip_address
+    opsmanager_security_group_name  = azurerm_network_security_group.ops-manager.name
+    opsmanager_private_key          = tls_private_key.ops_manager.private_key_pem
+    opsmanager_public_key           = tls_private_key.ops_manager.public_key_openssh
+    opsmanager_public_ip            = azurerm_public_ip.ops-manager.ip_address
+    opsmanager_container_name       = azurerm_storage_container.ops-manager.name
+    opsmanager_dns                  = "${azurerm_dns_a_record.opsmanager.name}.${azurerm_dns_a_record.opsmanager.zone_name}"
+    opsmanager_storage_account_name = azurerm_storage_account.ops-manager.name
 
-    container_opsmanager_image = azurerm_storage_container.ops-manager.name
-    container_pas_buildpacks   = azurerm_storage_container.pas-buildpacks.name
-    container_pas_packages     = azurerm_storage_container.pas-packages.name
-    container_pas_droplets     = azurerm_storage_container.pas-droplets.name
-    container_pas_resources    = azurerm_storage_container.pas-resources.name
+    platform_vms_security_group_name = azurerm_network_security_group.platform-vms.name
 
-    storage_account_bosh       = azurerm_storage_account.bosh.name
-    storage_account_opsmanager = azurerm_storage_account.ops-manager.name
-    storage_account_pas        = azurerm_storage_account.pas.name
+    pas_subnet_name                = azurerm_subnet.pas.name
+    pas_subnet_id                  = azurerm_subnet.pas.id
+    pas_subnet_cidr                = azurerm_subnet.pas.address_prefix
+    pas_subnet_gateway             = cidrhost(azurerm_subnet.pas.address_prefix, 1)
+    pas_buildpacks_container_name  = azurerm_storage_container.pas-buildpacks.name
+    pas_packages_container_name    = azurerm_storage_container.pas-packages.name
+    pas_droplets_container_name    = azurerm_storage_container.pas-droplets.name
+    pas_resources_container_name   = azurerm_storage_container.pas-resources.name
+    pas_storage_account_name       = azurerm_storage_account.pas.name
+    pas_storage_account_access_key = azurerm_storage_account.pas.primary_access_key
 
-    storage_account_pas_access_key = azurerm_storage_account.pas.primary_access_key
+    web_lb_name   = azurerm_lb.web.name
+    ssh_lb_name   = azurerm_lb.diego-ssh.name
+    mysql_lb_name = azurerm_lb.mysql.name
+    tcp_lb_name   = azurerm_lb.tcp.name
 
-    subnet_management_name    = azurerm_subnet.management.name
-    subnet_management_id      = azurerm_subnet.management.id
-    subnet_management_cidr    = azurerm_subnet.management.address_prefix
-    subnet_management_gateway = cidrhost(azurerm_subnet.management.address_prefix, 1)
+    apps_dns  = "${azurerm_dns_a_record.apps.name}.${azurerm_dns_a_record.apps.zone_name}"
+    ssh_dns   = "${azurerm_dns_a_record.ssh.name}.${azurerm_dns_a_record.ssh.zone_name}"
+    sys_dns   = "${azurerm_dns_a_record.sys.name}.${azurerm_dns_a_record.sys.zone_name}"
+    tcp_dns   = "${azurerm_dns_a_record.tcp.name}.${azurerm_dns_a_record.tcp.zone_name}"
+    mysql_dns = "${azurerm_dns_a_record.mysql.name}.${azurerm_dns_a_record.mysql.zone_name}"
 
-    subnet_pas_name    = azurerm_subnet.pas.name
-    subnet_pas_id      = azurerm_subnet.pas.id
-    subnet_pas_cidr    = azurerm_subnet.pas.address_prefix
-    subnet_pas_gateway = cidrhost(azurerm_subnet.pas.address_prefix, 1)
+    pks_as_name                                = azurerm_availability_set.pks_as.name
+    pks_lb_name                                = azurerm_lb.pks.name
+    pks_dns                                    = "${azurerm_dns_a_record.pks.name}.${azurerm_dns_a_record.pks.zone_name}"
+    pks_subnet_name                            = azurerm_subnet.pks.name
+    pks_subnet_id                              = azurerm_subnet.pks.id
+    pks_subnet_cidr                            = azurerm_subnet.pks.address_prefix
+    pks_subnet_gateway                         = cidrhost(azurerm_subnet.pks.address_prefix, 1)
+    pks_api_application_security_group_name    = azurerm_application_security_group.pks-api.name
+    pks_api_network_security_group_name        = azurerm_network_security_group.pks-api.name
+    pks_internal_network_security_group_name   = azurerm_network_security_group.pks-internal.name
+    pks_master_application_security_group_name = azurerm_application_security_group.pks-master.name
+    pks_master_network_security_group_name     = azurerm_network_security_group.pks-master.name
 
-    subnet_pks_name    = azurerm_subnet.pks.name
-    subnet_pks_id      = azurerm_subnet.pks.id
-    subnet_pks_cidr    = azurerm_subnet.pks.address_prefix
-    subnet_pks_gateway = cidrhost(azurerm_subnet.pks.address_prefix, 1)
-
-    subnet_services_name    = azurerm_subnet.services.name
-    subnet_services_id      = azurerm_subnet.services.id
-    subnet_services_cidr    = azurerm_subnet.services.address_prefix
-    subnet_services_gateway = cidrhost(azurerm_subnet.services.address_prefix, 1)
-
-    lb_web       = azurerm_lb.web.name
-    lb_diego_ssh = azurerm_lb.diego-ssh.name
-    lb_mysql     = azurerm_lb.mysql.name
-    lb_tcp       = azurerm_lb.tcp.name
-    lb_pks       = azurerm_lb.pks.name
-
-    dns_opsmanager = "${azurerm_dns_a_record.opsmanager.name}.${azurerm_dns_a_record.opsmanager.zone_name}"
-    dns_apps       = "${azurerm_dns_a_record.apps.name}.${azurerm_dns_a_record.apps.zone_name}"
-    dns_pks        = "${azurerm_dns_a_record.pks.name}.${azurerm_dns_a_record.pks.zone_name}"
-    dns_ssh        = "${azurerm_dns_a_record.ssh.name}.${azurerm_dns_a_record.ssh.zone_name}"
-    dns_sys        = "${azurerm_dns_a_record.sys.name}.${azurerm_dns_a_record.sys.zone_name}"
-    dns_tcp        = "${azurerm_dns_a_record.tcp.name}.${azurerm_dns_a_record.tcp.zone_name}"
-    dns_mysql      = "${azurerm_dns_a_record.mysql.name}.${azurerm_dns_a_record.mysql.zone_name}"
-
-    pks_as = azurerm_availability_set.pks_as.name
+    services_subnet_name    = azurerm_subnet.services.name
+    services_subnet_id      = azurerm_subnet.services.id
+    services_subnet_cidr    = azurerm_subnet.services.address_prefix
+    services_subnet_gateway = cidrhost(azurerm_subnet.services.address_prefix, 1)
   }
 }
 


### PR DESCRIPTION
cc @voor 

While wiring up the configuration files for the pipelines, I realized that it might be better to group objects not by the _type_ of the resource but by the product/component being configured (i.e. OM, PAS, PKS, etc.)

Wanted to make this a PR instead of a direct commit since you have a lot of the outputs already wired up. Lmk if this looks OK to you and I'll merge.