### PR TITLE
Loosely opinionated suggestions

### DIFF
--- a/azure/provider.tf
+++ b/azure/provider.tf
@@ -12,3 +12,11 @@ provider "azurerm" {
 terraform {
   required_version = ">= 0.12.0"
 }
+
+provider random {
+  version = "~> 2.2"
+}
+
+provider tls {
+  version = "~> 2.1"
+} 

--- a/azure/security_groups.tf
+++ b/azure/security_groups.tf
@@ -5,6 +5,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "internal-anything"
+    description                = "Allow internal traffic within the network"
     priority                   = 100
     direction                  = "Inbound"
     access                     = "Allow"
@@ -17,6 +18,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "ssh"
+    description                = "Allow SSH to VMs in the network"
     priority                   = 200
     direction                  = "Inbound"
     access                     = "Allow"
@@ -29,6 +31,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "bosh-agent"
+    description                = "Access to the bosh agent VM"
     priority                   = 201
     direction                  = "Inbound"
     access                     = "Allow"
@@ -41,6 +44,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "bosh-director"
+    description                = "Allow access to the bosh director"
     priority                   = 202
     direction                  = "Inbound"
     access                     = "Allow"
@@ -53,6 +57,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "dns"
+    description                = "Allow inbound DNS resolution"
     priority                   = 203
     direction                  = "Inbound"
     access                     = "Allow"
@@ -65,6 +70,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "http"
+    description                = "Allow inbound HTTP traffic from Internet"
     priority                   = 204
     direction                  = "Inbound"
     access                     = "Allow"
@@ -77,6 +83,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "https"
+    description                = "Allow inbound HTTPS traffic from Internet"
     priority                   = 205
     direction                  = "Inbound"
     access                     = "Allow"
@@ -89,6 +96,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "loggregator"
+    description                = "Allow inbound loggregator traffic from Internet"
     priority                   = 206
     direction                  = "Inbound"
     access                     = "Allow"
@@ -101,6 +109,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "diego-ssh"
+    description                = "Allow inbound diego ssh (different port) traffic from Internet"
     priority                   = 209
     direction                  = "Inbound"
     access                     = "Allow"
@@ -113,6 +122,7 @@ resource "azurerm_network_security_group" "platform-vms" {
 
   security_rule {
     name                       = "tcp"
+    description                = "Please explain this port range"
     priority                   = 210
     direction                  = "Inbound"
     access                     = "Allow"

--- a/azure/storage.tf
+++ b/azure/storage.tf
@@ -5,12 +5,15 @@ resource "random_string" "ops-manager" {
 }
 
 resource "azurerm_storage_account" "ops-manager" {
-  name                     = random_string.ops-manager.result
-  resource_group_name      = azurerm_resource_group.platform.name
-  location                 = var.location
-  account_tier             = "Standard"
-  account_kind             = "StorageV2"
-  account_replication_type = "LRS"
+  name                      = random_string.ops-manager.result
+  resource_group_name       = azurerm_resource_group.platform.name
+  location                  = var.location
+  account_tier              = "Standard"
+  account_kind              = "StorageV2"
+  account_replication_type  = "LRS"
+  enable_https_traffic_only = true
+
+  enable_advanced_threat_protection = false
 
   tags = merge(
     var.tags,
@@ -34,12 +37,15 @@ resource "random_string" "pas" {
 }
 
 resource "azurerm_storage_account" "pas" {
-  name                     = random_string.pas.result
-  resource_group_name      = azurerm_resource_group.platform.name
-  location                 = var.location
-  account_tier             = "Standard"
-  account_kind             = "StorageV2"
-  account_replication_type = "LRS"
+  name                      = random_string.pas.result
+  resource_group_name       = azurerm_resource_group.platform.name
+  location                  = var.location
+  account_tier              = "Standard"
+  account_kind              = "StorageV2"
+  account_replication_type  = "LRS"
+  enable_https_traffic_only = true
+
+  enable_advanced_threat_protection = false
 
   tags = merge(
     var.tags,
@@ -81,12 +87,15 @@ resource random_string "bosh" {
 }
 
 resource "azurerm_storage_account" "bosh" {
-  name                     = random_string.bosh.result
-  location                 = var.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  account_kind             = "StorageV2"
-  resource_group_name      = azurerm_resource_group.platform.name
+  name                      = random_string.bosh.result
+  location                  = var.location
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  account_kind              = "StorageV2"
+  resource_group_name       = azurerm_resource_group.platform.name
+  enable_https_traffic_only = true
+
+  enable_advanced_threat_protection = false
 
   tags = merge(
     var.tags,

--- a/azure/subnets.tf
+++ b/azure/subnets.tf
@@ -50,10 +50,10 @@ resource "azurerm_subnet" "pks" {
   virtual_network_name = azurerm_virtual_network.platform.name
   address_prefix       = var.pks_subnet_cidr
 
-  network_security_group_id = azurerm_network_security_group.platform-vms.id # Deprecated but required until AzureRM Provider 2.0
+  network_security_group_id = azurerm_network_security_group.pks-api.id # Deprecated but required until AzureRM Provider 2.0
 }
 
 resource "azurerm_subnet_network_security_group_association" "pks" {
   subnet_id                 = azurerm_subnet.pks.id
-  network_security_group_id = azurerm_network_security_group.platform-vms.id
+  network_security_group_id = azurerm_network_security_group.pks-api.id
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -68,3 +68,8 @@ variable "services_subnet_cidr" {
   default = "10.0.4.0/22"
   type    = string
 }
+
+variable "iaas_configuration_environment_azurecloud" {
+  default = "AzureCloud"
+  type    = string
+}

--- a/ci/configuration/azure/director.yml
+++ b/ci/configuration/azure/director.yml
@@ -12,6 +12,7 @@ properties-configuration:
     ssh_private_key: ((ops_manager_private_key))
     cloud_storage_type: managed_disks
     storage_account_type: Standard_LRS
+    environment: ((iaas_configuration_environment_azurecloud))
     availability_mode: availability_sets
   director_configuration:
     ntp_servers_string: 0.pool.ntp.org


### PR DESCRIPTION
`provider.tf` changes removes warnings
`security_groups.tf` is needed for idempotency, for some reason lack of description is creating issues in certain regions (terraform says it's `""` and Azure says it's `nil`)
`subnets.tf` The PKS subnet uses a different security group
`storage.tf` causes some 500 errors in GOV regions without these explicitly set.
`director.yml` needs another explicit variable for US Gov Regions, added a default for "everybody else"