### PR TITLE
Add PAS S3 bucket permissions to instance profile

### DIFF
--- a/aws/ops-manager.tf
+++ b/aws/ops-manager.tf
@@ -103,8 +103,16 @@ data "aws_iam_policy_document" "ops-manager" {
     effect  = "Allow"
     actions = ["s3:*"]
     resources = [
-      "arn:aws:s3:::${var.environment_name}-ops-manager-bucket",
-      "arn:aws:s3:::${var.environment_name}-ops-manager-bucket/*"
+      aws_s3_bucket.ops-manager-bucket.arn,
+      "${aws_s3_bucket.ops-manager-bucket.arn}/*",
+      aws_s3_bucket.buildpacks-bucket.arn,
+      "${aws_s3_bucket.buildpacks-bucket.arn}/*",
+      aws_s3_bucket.packages-bucket.arn,
+      "${aws_s3_bucket.packages-bucket.arn}/*",
+      aws_s3_bucket.resources-bucket.arn,
+      "${aws_s3_bucket.resources-bucket.arn}/*",
+      aws_s3_bucket.droplets-bucket.arn,
+      "${aws_s3_bucket.droplets-bucket.arn}/*"
     ]
   }
 


### PR DESCRIPTION
- Add all the S3 buckets used by PAS to the instance profile used by bosh deployed VMs
- Use the generated opsman bucket name