### PR TITLE
Fix generated opsman bucket name reference

### DIFF
--- a/aws/ops-manager.tf
+++ b/aws/ops-manager.tf
@@ -103,8 +103,8 @@ data "aws_iam_policy_document" "ops-manager" {
     effect  = "Allow"
     actions = ["s3:*"]
     resources = [
-      "arn:aws:s3:::${var.environment_name}-ops-manager-bucket",
-      "arn:aws:s3:::${var.environment_name}-ops-manager-bucket/*"
+      aws_s3_bucket.ops-manager-bucket.arn,
+      "${aws_s3_bucket.ops-manager-bucket.arn}/*"
     ]
   }
 


### PR DESCRIPTION
The generated bucket names have an integer suffix to ensure their uniqueness.