### PR TITLE
Adding Azure VM read permission to PKS workers

### DIFF
--- a/azure/iam.tf
+++ b/azure/iam.tf
@@ -27,6 +27,7 @@ resource "azurerm_role_definition" "pks-worker" {
   permissions {
     actions = [
       "Microsoft.Storage/storageAccounts/*",
+      "Microsoft.Compute/virtualMachines/read",
     ]
     not_actions = []
   }


### PR DESCRIPTION
This permission seems to be required for provisioning PersistentVolumes
when using a StorageClass that uses Azure managed disks. This feature
only became available in Azure v1.7.2, so it's possible our old testing
only included the old StorageClass configuration.

If this permission is missing from the k8s workers, Pods will not be able
to mount PersistentVolumes, and an error will appear in the k8s events
saying that the worker VM "does not have authorization to perform action
'Microsoft.Compute/virtualMachines/read'" on the disk.

## Steps to replicate this issue
1. Create a PKS cluster in Azure where the worker VMs do not have the `Microsoft.Compute/virtualMachines/read` permission.
1. Create the following StorageClass in your cluster:
    ```
    ---
    apiVersion: storage.k8s.io/v1
    kind: StorageClass
    metadata:
      annotations:
        storageclass.kubernetes.io/is-default-class: "true"
      name: default
    provisioner: kubernetes.io/azure-disk
    parameters:
      kind: Managed
      storageaccounttype: Premium_LRS
    ```
1. Try to deploy the [Bitnami MongoDB helm chart](https://github.com/bitnami/charts/tree/master/bitnami/mongodb). Any app that uses a PV should be able to replicate this, but this is what I was using when I encountered the issue.
    ```
    helm repo add bitnami https://charts.bitnami.com/bitnami
    helm install my-release bitnami/mongodb
    ```
1. Watch the events in your namespace with `kubectl get events -w`. The MongoDB Pod will never start, and eventually you will see the following error:
    ```
    39m         Warning   FailedMount               pod/madapi-mongodb-7767496887-rb54l                         MountVolume.WaitForAttach failed for volume "pvc-07748619-7351-11ea-8d4f-000d3aad1190" : compute.VirtualMachinesClient#Get: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailed" Message="The client 'b895f6cc-eeea-44dd-818c-af36f3480128' with object id 'b895f6cc-eeea-44dd-818c-af36f3480128' does not have authorization to perform action 'Microsoft.Compute/virtualMachines/read' over scope '/subscriptions/8dc4f332-756f-4fd3-9e67-bf6f4c497ad0/resourceGroups/sandbox/providers/Microsoft.Compute/virtualMachines/db4c1748-1b60-43f4-a1ec-91de40ff5384' or the scope is invalid. If access was recently granted, please refresh your credentials."
    ```