### PR TITLE
Add S3 permissions to PAS buckets

### DIFF
--- a/aws/ops-manager.tf
+++ b/aws/ops-manager.tf
@@ -104,7 +104,15 @@ data "aws_iam_policy_document" "ops-manager" {
     actions = ["s3:*"]
     resources = [
       aws_s3_bucket.ops-manager-bucket.arn,
-      "${aws_s3_bucket.ops-manager-bucket.arn}/*"
+      "${aws_s3_bucket.ops-manager-bucket.arn}/*",
+      aws_s3_bucket.buildpacks-bucket.arn,
+      "${aws_s3_bucket.buildpacks-bucket.arn}/*",
+      aws_s3_bucket.packages-bucket.arn,
+      "${aws_s3_bucket.packages-bucket.arn}/*" ,
+      aws_s3_bucket.resources-bucket.arn,
+      "${aws_s3_bucket.resources-bucket.arn}/*" ,
+      aws_s3_bucket.droplets-bucket.arn,
+      "${aws_s3_bucket.droplets-bucket.arn}/*"       
     ]
   }
 


### PR DESCRIPTION
Without this configuration, the following error occurs when using S3 as a PAS file storage

![image](https://user-images.githubusercontent.com/106908/85227489-d7259280-b418-11ea-80cf-eb12d2b70f23.png)
