### PR TITLE
Force destroy buckets

### DIFF
--- a/aws/buckets.tf
+++ b/aws/buckets.tf
@@ -6,6 +6,8 @@ resource "random_integer" "bucket_suffix" {
 resource "aws_s3_bucket" "ops-manager-bucket" {
   bucket = "${var.environment_name}-ops-manager-bucket-${random_integer.bucket_suffix.result}"
 
+  force_destroy = true
+
   versioning {
     enabled = true
   }
@@ -18,6 +20,8 @@ resource "aws_s3_bucket" "ops-manager-bucket" {
 
 resource "aws_s3_bucket" "buildpacks-bucket" {
   bucket = "${var.environment_name}-buildpacks-bucket-${random_integer.bucket_suffix.result}"
+
+  force_destroy = true
 
   versioning {
     enabled = true
@@ -32,6 +36,8 @@ resource "aws_s3_bucket" "buildpacks-bucket" {
 resource "aws_s3_bucket" "packages-bucket" {
   bucket = "${var.environment_name}-packages-bucket-${random_integer.bucket_suffix.result}"
 
+  force_destroy = true
+
   versioning {
     enabled = true
   }
@@ -45,6 +51,8 @@ resource "aws_s3_bucket" "packages-bucket" {
 resource "aws_s3_bucket" "resources-bucket" {
   bucket = "${var.environment_name}-resources-bucket-${random_integer.bucket_suffix.result}"
 
+  force_destroy = true
+
   versioning {
     enabled = true
   }
@@ -57,6 +65,8 @@ resource "aws_s3_bucket" "resources-bucket" {
 
 resource "aws_s3_bucket" "droplets-bucket" {
   bucket = "${var.environment_name}-droplets-bucket-${random_integer.bucket_suffix.result}"
+
+  force_destroy = true
 
   versioning {
     enabled = true


### PR DESCRIPTION
This commit forces the s3 bucket to be destroyed as same as [terraforming-aws](https://github.com/pivotal-cf/terraforming-aws/blob/master/modules/pas/s3.tf).

Without this configuration `terraform destroy` fails when using s3 buckets as a PAS file storage