### PR TITLE
Azure: fix subnet reserved ranges

### DIFF
--- a/azure/ops-manager-outputs.tf
+++ b/azure/ops-manager-outputs.tf
@@ -15,13 +15,13 @@ locals {
     management_subnet_id      = azurerm_subnet.management.id
     management_subnet_cidr    = azurerm_subnet.management.address_prefix
     management_subnet_gateway = cidrhost(azurerm_subnet.management.address_prefix, 1)
-    management_subnet_range   = cidrhost(azurerm_subnet.management.address_prefix, 10)
+    management_subnet_range   = "${cidrhost(azurerm_subnet.management.address_prefix, 1)}-${cidrhost(azurerm_subnet.management.address_prefix, 10)}"
 
     bosh_storage_account_name = azurerm_storage_account.bosh.name
 
     ops_manager_security_group_name  = azurerm_network_security_group.ops-manager.name
-    ops_manager_ssh_private_key          = tls_private_key.ops_manager.private_key_pem
-    ops_manager_ssh_public_key           = tls_private_key.ops_manager.public_key_openssh
+    ops_manager_ssh_private_key      = tls_private_key.ops_manager.private_key_pem
+    ops_manager_ssh_public_key       = tls_private_key.ops_manager.public_key_openssh
     ops_manager_private_ip           = cidrhost(azurerm_subnet.management.address_prefix, 5)
     ops_manager_public_ip            = azurerm_public_ip.ops-manager.ip_address
     ops_manager_container_name       = azurerm_storage_container.ops-manager.name
@@ -36,7 +36,7 @@ locals {
     services_subnet_id      = azurerm_subnet.services.id
     services_subnet_cidr    = azurerm_subnet.services.address_prefix
     services_subnet_gateway = cidrhost(azurerm_subnet.services.address_prefix, 1)
-    services_subnet_range   = cidrhost(azurerm_subnet.services.address_prefix, 10)
+    services_subnet_range   = "${cidrhost(azurerm_subnet.services.address_prefix, 1)}-${cidrhost(azurerm_subnet.services.address_prefix, 10)}"
 
     ssl_certificate = var.ssl_certificate
     ssl_private_key = var.ssl_private_key

--- a/azure/pas-outputs.tf
+++ b/azure/pas-outputs.tf
@@ -1,31 +1,31 @@
 locals {
   stable_config_pas = {
-    pas_subnet_name = azurerm_subnet.pas.name
-    pas_subnet_id = azurerm_subnet.pas.id
-    pas_subnet_cidr = azurerm_subnet.pas.address_prefix
-    pas_subnet_gateway = cidrhost(azurerm_subnet.pas.address_prefix, 1)
-    pas_subnet_range = cidrhost(azurerm_subnet.pas.address_prefix, 10)
-    pas_buildpacks_container_name = azurerm_storage_container.pas-buildpacks.name
-    pas_packages_container_name = azurerm_storage_container.pas-packages.name
-    pas_droplets_container_name = azurerm_storage_container.pas-droplets.name
-    pas_resources_container_name = azurerm_storage_container.pas-resources.name
-    pas_storage_account_name = azurerm_storage_account.pas.name
+    pas_subnet_name                = azurerm_subnet.pas.name
+    pas_subnet_id                  = azurerm_subnet.pas.id
+    pas_subnet_cidr                = azurerm_subnet.pas.address_prefix
+    pas_subnet_gateway             = cidrhost(azurerm_subnet.pas.address_prefix, 1)
+    pas_subnet_range               = "${cidrhost(azurerm_subnet.pas.address_prefix, 1)}-${cidrhost(azurerm_subnet.pas.address_prefix, 10)}"
+    pas_buildpacks_container_name  = azurerm_storage_container.pas-buildpacks.name
+    pas_packages_container_name    = azurerm_storage_container.pas-packages.name
+    pas_droplets_container_name    = azurerm_storage_container.pas-droplets.name
+    pas_resources_container_name   = azurerm_storage_container.pas-resources.name
+    pas_storage_account_name       = azurerm_storage_account.pas.name
     pas_storage_account_access_key = azurerm_storage_account.pas.primary_access_key
 
-    web_lb_name = azurerm_lb.web.name
-    ssh_lb_name = azurerm_lb.diego-ssh.name
+    web_lb_name   = azurerm_lb.web.name
+    ssh_lb_name   = azurerm_lb.diego-ssh.name
     mysql_lb_name = azurerm_lb.mysql.name
-    tcp_lb_name = azurerm_lb.tcp.name
+    tcp_lb_name   = azurerm_lb.tcp.name
 
     apps_dns_domain = "${replace(azurerm_dns_a_record.apps.name, "*.", "")}.${azurerm_dns_a_record.apps.zone_name}"
-    sys_dns_domain = "${replace(azurerm_dns_a_record.sys.name, "*.", "")}.${azurerm_dns_a_record.sys.zone_name}"
-    ssh_dns = "${azurerm_dns_a_record.ssh.name}.${azurerm_dns_a_record.ssh.zone_name}"
-    tcp_dns = "${azurerm_dns_a_record.tcp.name}.${azurerm_dns_a_record.tcp.zone_name}"
-    mysql_dns = "${azurerm_dns_a_record.mysql.name}.${azurerm_dns_a_record.mysql.zone_name}"
+    sys_dns_domain  = "${replace(azurerm_dns_a_record.sys.name, "*.", "")}.${azurerm_dns_a_record.sys.zone_name}"
+    ssh_dns         = "${azurerm_dns_a_record.ssh.name}.${azurerm_dns_a_record.ssh.zone_name}"
+    tcp_dns         = "${azurerm_dns_a_record.tcp.name}.${azurerm_dns_a_record.tcp.zone_name}"
+    mysql_dns       = "${azurerm_dns_a_record.mysql.name}.${azurerm_dns_a_record.mysql.zone_name}"
   }
 }
 
 output "stable_config_pas" {
-  value = jsonencode(local.stable_config_pas)
+  value     = jsonencode(local.stable_config_pas)
   sensitive = true
 }


### PR DESCRIPTION
The reserved range is a range of IP addresses, so the output should reserve the first 10 IPs in each subnet, not only the 10th IP.

With this change, the output shows:

```
➜ terraform output stable_config_pas | jq .pas_subnet_range
"10.0.0.1-10.0.0.10"
```
