### PR TITLE
Generate list of backends dynamically in the HTTP load balancer for PAS in GCP

### DIFF
--- a/gcp/pas-lbs.tf
+++ b/gcp/pas-lbs.tf
@@ -6,12 +6,12 @@ resource "google_compute_backend_service" "http-lb" {
   timeout_sec = 900
   enable_cdn  = false
 
-  backend {
-    group = google_compute_instance_group.http-lb[0].self_link
-  }
-
-  backend {
-    group = google_compute_instance_group.http-lb[1].self_link
+  dynamic "backend" {
+    for_each = { for group in google_compute_instance_group.http-lb.* : group.self_link => group }
+    iterator = instance_group
+    content {
+      group = instance_group.value.self_link
+    }
   }
 
   health_checks = [google_compute_http_health_check.http-lb.self_link]


### PR DESCRIPTION
Current code is only assigning two of the instance groups to the HTTP load balancer, but there is one for each availability zone.

TAS installation in three availability zones fails with errors like these ones when router is assigned to the HTTP load balancers:
```
Task 1581 | 14:42:37 | L executing post-stop: router/c5b35b8f-ba4a-40ad-b412-845d95004f2f (2) (canary) (00:16:22)
                   L Error: CPI error 'Bosh::Clouds::VMCreationFailed' with message 'VM failed to create: Backend Service "pcf-http-lb" does not contain any Unmanaged Instance Groups in zone "europe-west2-c"' in 'create_vm' CPI method (CPI request ID: 'cpi-628147')
Task 1581 | 14:58:21 | Error: CPI error 'Bosh::Clouds::VMCreationFailed' with message 'VM failed to create: Backend Service "pcf-http-lb" does not contain any Unmanaged Instance Groups in zone "europe-west2-c"' in 'create_vm' CPI method (CPI request ID: 'cpi-628147')
```