### PR TITLE
Add NAT router configuration also for Ops Manager

### DIFF
--- a/gcp/ops-manager-nat.tf
+++ b/gcp/ops-manager-nat.tf
@@ -30,5 +30,10 @@ resource "google_compute_router_nat" "nat" {
     name                    = google_compute_subnetwork.services.self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
+
+  subnetwork {
+    name                    = google_compute_subnetwork.management.self_link
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
 }
 


### PR DESCRIPTION
Terraform configuration creates an storage bucket for the Ops Manager,
but Ops Manager cannot connect to google cloud if it doesn't have a NAT
router.