### PR TITLE
Add a prerequisite to paving GCP

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -3,6 +3,11 @@
 Follow [these instructions](https://docs.pivotal.io/platform/ops-manager/2-8/gcp/prepare-env-terraform.html)
 to create the service account that is needed to run the terraform templates.
 
+
+### Prerequisites
+- a pre-created zone in GCP (see the [google docs](https://cloud.google.com/dns/docs/zones#creating_managed_zones) for details)
+    - the `Zone name` maps to `hosted_zone` in `terraform.tfvars`
+
 ### Roles & Permissions
 
 If you are looking to create a service account with more restrictive permissions,


### PR DESCRIPTION
cannot run `terraform plan` without a pre-created zone in GCP