### PR TITLE
Change gcp director resource config to automatic

### DIFF
--- a/ci/configuration/gcp/director.yml
+++ b/ci/configuration/gcp/director.yml
@@ -46,4 +46,4 @@ properties-configuration:
 resource-configuration:
   compilation:
     instance_type:
-      id: xlarge.disk
+      id: automatic


### PR DESCRIPTION
When using the `director.yml` for GCP in [opsman 3.0-beta](https://network.pivotal.io/products/ops-manager/) to configure a director's resource, we saw following error
```
started configuring resource options for bosh tile
2022/09/28 04:17:02 failed to configure resources: failed to configure resources for compilation: request failed: unexpected response from /api/v0/staged/products/p-bosh-5af99658ed65c28fe93d/jobs/compilation-d7c05181d96d7b2318f7/resource_config:
HTTP/1.1 422 Unprocessable Entity
Transfer-Encoding: chunked
Cache-Control: private, no-store
Connection: keep-alive
Content-Security-Policy: script-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; object-src 'none';
Content-Type: application/json; charset=utf-8
Date: Wed, 28 Sep 2022 04:17:02 GMT
Expires: Fri, 01 Jan 1990 00:00:00 GMT
Pragma: no-cache
Referrer-Policy: strict-origin-when-cross-origin
Server: Ops Manager
Strict-Transport-Security: max-age=63072000; includeSubDomains
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Request-Id: 280c9661-7258-4f40-a987-758537675545
X-Runtime: 0.059807

47
{"errors":{"instance_type_id":["must be in catalog or \"automatic\""]}}
0
```

On opsman resource config page, the screenshot shows `xlarge.disk`  is not available anymore.
<img width="1581" alt="Screen Shot 2022-09-28 at 3 21 16 PM" src="https://user-images.githubusercontent.com/1585949/192873935-aa6db130-5f58-4ed5-b29e-0518445579fa.png">

In such case, making it to `automatic` would be more robust for future change and it aligns with same config for AWS.
