### PR TITLE
revert Cloudgate changes in release branch

### DIFF
--- a/aws/ops-manager-outputs.tf
+++ b/aws/ops-manager-outputs.tf
@@ -25,9 +25,8 @@ locals {
     ops_manager_subnet_id                 = aws_subnet.public-subnet[0].id
     ops_manager_public_ip                 = aws_eip.ops-manager.public_ip
     ops_manager_dns                       = aws_route53_record.ops-manager.name
-    ops_manager_iam_user_access_key       = var.access_key
-    ops_manager_iam_user_secret_key       = var.secret_key
-    ops_manager_role_arn                  = var.role_arn
+    ops_manager_iam_user_access_key       = aws_iam_access_key.ops-manager.id
+    ops_manager_iam_user_secret_key       = aws_iam_access_key.ops-manager.secret
     ops_manager_iam_instance_profile_name = aws_iam_instance_profile.ops-manager.name
     ops_manager_key_pair_name             = aws_key_pair.ops-manager.key_name
     ops_manager_ssh_public_key            = tls_private_key.ops-manager.public_key_openssh

--- a/aws/ops-manager.tf
+++ b/aws/ops-manager.tf
@@ -17,13 +17,167 @@ resource "tls_private_key" "ops-manager" {
   rsa_bits  = "4096"
 }
 
+resource "aws_iam_access_key" "ops-manager" {
+  user = aws_iam_user.ops-manager.name
+}
+
+resource "aws_iam_policy" "ops-manager-role" {
+  name   = "${var.environment_name}-ops-manager-role"
+  policy = data.aws_iam_policy_document.ops-manager.json
+}
+
+resource "aws_iam_role_policy_attachment" "ops-manager-policy" {
+  role       = aws_iam_role.ops-manager.name
+  policy_arn = aws_iam_policy.ops-manager-role.arn
+}
+
+resource "aws_iam_role" "ops-manager" {
+  name = "${var.environment_name}-ops-manager-role"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+
+}
+
 resource "aws_iam_instance_profile" "ops-manager" {
   name = "${var.environment_name}-ops-manager"
-  role = var.cloudgate_opsman_role_name
+  role = aws_iam_role.ops-manager.name
 
   lifecycle {
     ignore_changes = [name]
   }
+}
+
+resource "aws_iam_user" "ops-manager" {
+  force_destroy = true
+  name          = "${var.environment_name}-ops-manager"
+}
+
+resource "aws_iam_user_policy" "ops-manager" {
+  name   = "${var.environment_name}-ops-manager-policy"
+  user   = aws_iam_user.ops-manager.name
+  policy = data.aws_iam_policy_document.ops-manager.json
+}
+
+data "aws_iam_policy_document" "ops-manager" {
+  statement {
+    sid       = "OpsMgrInfoAboutCurrentInstanceProfile"
+    effect    = "Allow"
+    actions   = ["iam:GetInstanceProfile"]
+    resources = [aws_iam_instance_profile.ops-manager.arn]
+  }
+
+  statement {
+    sid     = "OpsMgrCreateInstanceWithCurrentInstanceProfile"
+    effect  = "Allow"
+    actions = ["iam:PassRole"]
+    resources = compact([
+      aws_iam_role.ops-manager.arn,
+      aws_iam_role.pas-blobstore.arn,
+      aws_iam_role.pks-master.arn,
+      aws_iam_role.pks-worker.arn,
+    ])
+  }
+
+  statement {
+    sid     = "OpsMgrS3Permissions"
+    effect  = "Allow"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.ops-manager-bucket.arn,
+      "${aws_s3_bucket.ops-manager-bucket.arn}/*"
+    ]
+  }
+
+  statement {
+    sid    = "OpsMgrEC2Permissions"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeKeypairs",
+      "ec2:DescribeVpcs",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeImages",
+      "ec2:DeregisterImage",
+      "ec2:DescribeSubnets",
+      "ec2:RunInstances",
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+      "ec2:DescribeInstances",
+      "ec2:TerminateInstances",
+      "ec2:RebootInstances",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeTargetHealth",
+      "elasticloadbalancing:RegisterTargets",
+      "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+      "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+      "ec2:DescribeAddresses",
+      "ec2:DisassociateAddress",
+      "ec2:AssociateAddress",
+      "ec2:CreateTags",
+      "ec2:DescribeVolumes",
+      "ec2:CreateVolume",
+      "ec2:AttachVolume",
+      "ec2:DeleteVolume",
+      "ec2:DetachVolume",
+      "ec2:ModifyVolume",
+      "ec2:CreateSnapshot",
+      "ec2:DeleteSnapshot",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeRegions"
+    ]
+    resources = ["*"]
+  }
+}
+
+// NOTE: here because it gets consumed by the opsmanager policy
+resource "aws_iam_role" "pas-blobstore" {
+  name = "${var.environment_name}-pas-blobstore"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
 }
 
 // NOTE: here because it gets consumed by the opsmanager policy
@@ -36,4 +190,26 @@ data "aws_iam_policy_document" "assume-role-policy" {
       identifiers = ["ec2.amazonaws.com"]
     }
   }
+}
+
+// NOTE: here because it gets consumed by the opsmanager policy
+resource "aws_iam_role" "pks-master" {
+  name = "${var.environment_name}-pks-master"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  assume_role_policy = data.aws_iam_policy_document.assume-role-policy.json
+}
+
+// NOTE: here because it gets consumed by the opsmanager policy
+resource "aws_iam_role" "pks-worker" {
+  name = "${var.environment_name}-pks-worker"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  assume_role_policy = data.aws_iam_policy_document.assume-role-policy.json
 }

--- a/aws/pas-iam.tf
+++ b/aws/pas-iam.tf
@@ -16,9 +16,19 @@ data "aws_iam_policy_document" "pas-blobstore-policy" {
   }
 }
 
+resource "aws_iam_policy" "pas-blobstore" {
+  name   = "${var.environment_name}-pas-blobstore-policy"
+  policy = data.aws_iam_policy_document.pas-blobstore-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "pas-blobstore" {
+  role       = aws_iam_role.pas-blobstore.name
+  policy_arn = aws_iam_policy.pas-blobstore.arn
+}
+
 resource "aws_iam_instance_profile" "pas-blobstore" {
   name = "${var.environment_name}-pas-blobstore"
-  role = "cloudgate-paving-aws-pas-blobstore"
+  role = aws_iam_role.pas-blobstore.name
 
   lifecycle {
     ignore_changes = [name]

--- a/aws/pks-iam.tf
+++ b/aws/pks-iam.tf
@@ -67,9 +67,19 @@ data "aws_iam_policy_document" "pks-master-policy" {
   }
 }
 
+resource "aws_iam_policy" "pks-master" {
+  name   = "${var.environment_name}-pks-master-policy"
+  policy = data.aws_iam_policy_document.pks-master-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "pks-master" {
+  role       = aws_iam_role.pks-master.name
+  policy_arn = aws_iam_policy.pks-master.arn
+}
+
 resource "aws_iam_instance_profile" "pks-master" {
   name = "${var.environment_name}-pks-master"
-  role = "cloudgate-paving-aws-pks-master"
+  role = aws_iam_role.pks-master.name
 
   lifecycle {
     ignore_changes = [name]
@@ -100,9 +110,19 @@ data "aws_iam_policy_document" "pks-worker-policy" {
   }
 }
 
+resource "aws_iam_policy" "pks-worker" {
+  name   = "${var.environment_name}-pks-worker-policy"
+  policy = data.aws_iam_policy_document.pks-worker-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "pks-worker" {
+  role       = aws_iam_role.pks-worker.name
+  policy_arn = aws_iam_policy.pks-worker.arn
+}
+
 resource "aws_iam_instance_profile" "pks-worker" {
   name = "${var.environment_name}-pks-worker"
-  role = "cloudgate-paving-aws-pks-worker"
+  role = aws_iam_role.pks-worker.name
 
   lifecycle {
     ignore_changes = [name]

--- a/aws/provider.tf
+++ b/aws/provider.tf
@@ -2,7 +2,5 @@ provider "aws" {
   region     = var.region
   access_key = var.access_key
   secret_key = var.secret_key
-  assume_role {
-      role_arn = var.role_arn
-  }
 }
+

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -3,10 +3,6 @@ environment_name = "YOUR-ENVIRONMNET-NAME"
 access_key = "YOUR-AWS-ACCESS-KEY"
 secret_key = "YOUR-AWS-SECRET-KEY"
 
-role_arn = "YOUR-AWS-ROLE-ARN"
-svc_role_name = "YOUR-AWS-SERVICE-ACCOUNT-ROLE-NAME"
-cloudgate_opsman_role_name = "YOUR-AWS-OPSMAN-ROLE-NAME"
-
 region = "YOUR-AWS-REGION"
 availability_zones = ["YOUR-AWS-ZONE-1", "YOUR-AWS-ZONE-2", "YOUR-AWS-ZONE-3"]
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -6,18 +6,6 @@ variable "secret_key" {
   type = string
 }
 
-variable "role_arn" {
-  type = string
-}
-
-variable "svc_role_name" {
-  type = string
-}
-
-variable "cloudgate_opsman_role_name" {
-  type = string
-}
-
 variable "environment_name" {
   type = string
 }

--- a/ci/configuration/aws/director.yml
+++ b/ci/configuration/aws/director.yml
@@ -63,7 +63,6 @@ properties-configuration:
   iaas_configuration:
     access_key_id: ((ops_manager_iam_user_access_key))
     secret_access_key: ((ops_manager_iam_user_secret_key))
-    role_arn: ((ops_manager_role_arn))
     iam_instance_profile: ((ops_manager_iam_instance_profile_name))
     vpc_id: ((vpc_id))
     security_group: ((platform_vms_security_group_id))

--- a/ci/configuration/aws/ops-manager.yml
+++ b/ci/configuration/aws/ops-manager.yml
@@ -2,14 +2,13 @@
 opsman-configuration:
   aws:
     access_key_id: ((access_key))
-    assume_role: ((ops_manager_role_arn))
     boot_disk_size: 100
     iam_instance_profile_name: ((ops_manager_iam_instance_profile_name))
     instance_type: m5.large
     key_pair_name: ((ops_manager_key_pair_name))
     public_ip: ((ops_manager_public_ip))
     region: ((region))
-    security_group_ids: [((ops_manager_security_group_id))]
     secret_access_key: ((secret_key))
+    security_group_ids: [((ops_manager_security_group_id))]
     vm_name: ((environment_name))-ops-manager-vm
     vpc_subnet_id: ((ops_manager_subnet_id))

--- a/ci/pipelines/pipeline.yml
+++ b/ci/pipelines/pipeline.yml
@@ -26,7 +26,7 @@ resources:
   type: git
   source:
     uri: https://github.com/pivotal/paving
-    branch: release
+    branch: master
 - name: rc-tasks-s3
   type: s3
   source:
@@ -138,7 +138,7 @@ jobs:
       BBL_IAAS: aws
       BBL_AWS_ACCESS_KEY_ID: ((s3.access_key_id))
       BBL_AWS_SECRET_ACCESS_KEY: ((s3.secret_access_key))
-      BBL_AWS_REGION: "us-east-2"
+      BBL_AWS_REGION: ((s3.region_name))
       BBL_AZURE_CLIENT_ID: ((azure.client_id))
       BBL_AZURE_CLIENT_SECRET: ((azure.client_secret))
       BBL_AZURE_TENANT_ID: ((azure.tenant_id))

--- a/ci/pipelines/pipeline.yml
+++ b/ci/pipelines/pipeline.yml
@@ -136,10 +136,9 @@ jobs:
     file: docs-platform-automation/ci/tasks/leftovers.yml
     params:
       BBL_IAAS: aws
-      BBL_AWS_ACCESS_KEY_ID: ((paving-aws.access_key_id))
-      BBL_AWS_SECRET_ACCESS_KEY: ((paving-aws.secret_access_key))
-      BBL_AWS_ASSUME_ROLE: ((paving-aws.role_arn))
-      BBL_AWS_REGION: ((paving-aws.region_name))
+      BBL_AWS_ACCESS_KEY_ID: ((s3.access_key_id))
+      BBL_AWS_SECRET_ACCESS_KEY: ((s3.secret_access_key))
+      BBL_AWS_REGION: "us-east-2"
       BBL_AZURE_CLIENT_ID: ((azure.client_id))
       BBL_AZURE_CLIENT_SECRET: ((azure.client_secret))
       BBL_AZURE_TENANT_ID: ((azure.tenant_id))


### PR DESCRIPTION
The changes made in the `release` branch are consumed directly, so changes that target our use case specifically should be made in a branch (pushed to the `low-privilege` branch in this case).