### PR TITLE
chore: stepping stone to pave GovCloud

### DIFF
--- a/aws/govcloud.tf
+++ b/aws/govcloud.tf
@@ -1,0 +1,43 @@
+/*
+  This is a stepping stone to reuse existing knowledge on paving AWS
+  and applying it to GovCloud with as few changes as possible.
+  This is an opt-in change and fully backward compatible out-of-the-box.
+
+  Given the strict requirements associated to any AWS GovCloud, it is
+  unfeasible for us to provide any kind of support for GovCloud.
+
+  DISCLAIMER:
+
+  This opt-in functionality is provided AS-IS. We make no warranties,
+  express or implied, and hereby disclaims all implied warranties,
+  including any warranty of merchantability and warranty of fitness
+  for a particular purpose.
+*/
+
+variable "public_dns_access_key" {
+  type = string
+  default = ""
+}
+
+variable "public_dns_secret_key" {
+  type = string
+  default = ""
+}
+
+variable "public_dns_region" {
+  type = string
+  default = ""
+}
+
+locals {
+  public_dns_access_key = var.public_dns_access_key != "" ? var.public_dns_access_key : var.access_key
+  public_dns_secret_key = var.public_dns_secret_key != "" ? var.public_dns_secret_key : var.secret_key
+  public_dns_region = var.public_dns_region != "" ? var.public_dns_region : var.region
+}
+
+provider "aws" {
+  alias      = "public-dns"
+  region     = local.public_dns_region
+  access_key = local.public_dns_access_key
+  secret_key = local.public_dns_secret_key
+}

--- a/aws/ops-manager-dns.tf
+++ b/aws/ops-manager-dns.tf
@@ -1,8 +1,12 @@
 data "aws_route53_zone" "hosted" {
+  provider = aws.public-dns
+
   name = var.hosted_zone
 }
 
 resource "aws_route53_record" "ops-manager" {
+  provider = aws.public-dns
+
   name = "opsmanager.${var.environment_name}.${data.aws_route53_zone.hosted.name}"
 
   zone_id = data.aws_route53_zone.hosted.zone_id

--- a/aws/pas-dns.tf
+++ b/aws/pas-dns.tf
@@ -1,4 +1,6 @@
 resource "aws_route53_record" "wildcard-sys" {
+  provider = aws.public-dns
+
   name = "*.sys.${var.environment_name}.${data.aws_route53_zone.hosted.name}"
 
   zone_id = data.aws_route53_zone.hosted.zone_id
@@ -12,6 +14,8 @@ resource "aws_route53_record" "wildcard-sys" {
 }
 
 resource "aws_route53_record" "wildcard-apps" {
+  provider = aws.public-dns
+
   name = "*.apps.${var.environment_name}.${data.aws_route53_zone.hosted.name}"
 
   zone_id = data.aws_route53_zone.hosted.zone_id
@@ -25,6 +29,8 @@ resource "aws_route53_record" "wildcard-apps" {
 }
 
 resource "aws_route53_record" "ssh" {
+  provider = aws.public-dns
+
   name = "ssh.sys.${var.environment_name}.${data.aws_route53_zone.hosted.name}"
 
   zone_id = data.aws_route53_zone.hosted.zone_id
@@ -38,6 +44,8 @@ resource "aws_route53_record" "ssh" {
 }
 
 resource "aws_route53_record" "tcp" {
+  provider = aws.public-dns
+
   name = "tcp.${var.environment_name}.${data.aws_route53_zone.hosted.name}"
 
   zone_id = data.aws_route53_zone.hosted.zone_id


### PR DESCRIPTION
AWS paving templates assumed DNS records are public and that it is possible to create Alias records pointing to some of the created resources. However, AWS GovCloud docs specify:

> Route 53 public hosted zones are not available.
> [...]
> you can create alias records only when the alias target is
> another record in the same hosted zone. To route traffic
> to another AWS resource, such as an ELB load balancer or
> an S3 bucket, you can use a CNAME record instead

https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-r53.html#govcloud-r53-diffs

I tried replacing Alias with CNAME records but there was another challenge: OpsManager and other records were not reachable from the public internet.

While that might be desirable in some contexts, it didn't play well with existing automations. So, I followed other AWS GovCloud guidelines for "Setting Up Amazon Route 53":

> To use Route 53 public DNS to respond to internet DNS
> queries for resources that you created using a GovCloud
> account, you must create a public hosted zone using a
> global AWS account, and create records in the hosted zone
> that specify the GovCloud resources.

https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/setting-up-route53.html

This is an opt-in change and fully backward compatible out-of-the-box. To enable it:

Variables:
- `access_key`
- `secret_key`
- `region` Should take their values from a GovCloud account

Variables:
- `public_dns_access_key`
- `public_dns_secret_key`
- `public_dns_region` Should take their values from a non-GovCloud account

There is no change needed to opt-out of this functionality since everything will behave exactly as before if variables with the prefix `public_dns` are left unspecified, and these variables were introduced in this change.
Therefore, any automation will still work without changes.