### PR TITLE
chore: update to AzureRM provider v4

### DIFF
--- a/azure/ops-manager-outputs.tf
+++ b/azure/ops-manager-outputs.tf
@@ -13,16 +13,16 @@ locals {
 
     management_subnet_name    = azurerm_subnet.management.name
     management_subnet_id      = azurerm_subnet.management.id
-    management_subnet_cidr    = azurerm_subnet.management.address_prefix
-    management_subnet_gateway = cidrhost(azurerm_subnet.management.address_prefix, 1)
-    management_subnet_range   = cidrhost(azurerm_subnet.management.address_prefix, 10)
+    management_subnet_cidr    = azurerm_subnet.management.address_prefixes[0]
+    management_subnet_gateway = cidrhost(azurerm_subnet.management.address_prefixes[0], 1)
+    management_subnet_range   = cidrhost(azurerm_subnet.management.address_prefixes[0], 10)
 
     bosh_storage_account_name = azurerm_storage_account.bosh.name
 
     ops_manager_security_group_name  = azurerm_network_security_group.ops-manager.name
-    ops_manager_ssh_private_key          = tls_private_key.ops_manager.private_key_pem
-    ops_manager_ssh_public_key           = tls_private_key.ops_manager.public_key_openssh
-    ops_manager_private_ip           = cidrhost(azurerm_subnet.management.address_prefix, 5)
+    ops_manager_ssh_private_key      = tls_private_key.ops_manager.private_key_pem
+    ops_manager_ssh_public_key       = tls_private_key.ops_manager.public_key_openssh
+    ops_manager_private_ip           = cidrhost(azurerm_subnet.management.address_prefixes[0], 5)
     ops_manager_public_ip            = azurerm_public_ip.ops-manager.ip_address
     ops_manager_container_name       = azurerm_storage_container.ops-manager.name
     ops_manager_dns                  = "${azurerm_dns_a_record.ops-manager.name}.${azurerm_dns_a_record.ops-manager.zone_name}"
@@ -34,9 +34,9 @@ locals {
 
     services_subnet_name    = azurerm_subnet.services.name
     services_subnet_id      = azurerm_subnet.services.id
-    services_subnet_cidr    = azurerm_subnet.services.address_prefix
-    services_subnet_gateway = cidrhost(azurerm_subnet.services.address_prefix, 1)
-    services_subnet_range   = cidrhost(azurerm_subnet.services.address_prefix, 10)
+    services_subnet_cidr    = azurerm_subnet.services.address_prefixes[0]
+    services_subnet_gateway = cidrhost(azurerm_subnet.services.address_prefixes[0], 1)
+    services_subnet_range   = cidrhost(azurerm_subnet.services.address_prefixes[0], 10)
 
     ssl_certificate = var.ssl_certificate
     ssl_private_key = var.ssl_private_key

--- a/azure/ops-manager-storage.tf
+++ b/azure/ops-manager-storage.tf
@@ -5,13 +5,13 @@ resource "random_string" "ops-manager" {
 }
 
 resource "azurerm_storage_account" "ops-manager" {
-  name                      = random_string.ops-manager.result
-  resource_group_name       = azurerm_resource_group.platform.name
-  location                  = var.location
-  account_tier              = "Standard"
-  account_kind              = "StorageV2"
-  account_replication_type  = "LRS"
-  enable_https_traffic_only = true
+  name                       = random_string.ops-manager.result
+  resource_group_name        = azurerm_resource_group.platform.name
+  location                   = var.location
+  account_tier               = "Standard"
+  account_kind               = "StorageV2"
+  account_replication_type   = "LRS"
+  https_traffic_only_enabled = true
 
   tags = merge(
     var.tags,
@@ -34,7 +34,7 @@ resource "azurerm_advanced_threat_protection" "ops-manager" {
 
 resource "azurerm_storage_container" "ops-manager" {
   name                  = "opsmanagerimage"
-  storage_account_name  = azurerm_storage_account.ops-manager.name
+  storage_account_id    = azurerm_storage_account.ops-manager.id
   container_access_type = "private"
 }
 
@@ -45,14 +45,14 @@ resource "random_string" "bosh" {
 }
 
 resource "azurerm_storage_account" "bosh" {
-  name                      = random_string.bosh.result
-  location                  = var.location
-  account_tier              = "Standard"
-  account_replication_type  = "LRS"
-  account_kind              = "StorageV2"
-  resource_group_name       = azurerm_resource_group.platform.name
-  enable_https_traffic_only = true
-  allow_blob_public_access  = true
+  name                            = random_string.bosh.result
+  location                        = var.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  account_kind                    = "StorageV2"
+  resource_group_name             = azurerm_resource_group.platform.name
+  https_traffic_only_enabled      = true
+  allow_nested_items_to_be_public = true
 
   tags = merge(
     var.tags,
@@ -82,14 +82,14 @@ resource "azurerm_advanced_threat_protection" "bosh" {
 resource "azurerm_storage_container" "bosh" {
   name                  = "bosh"
   depends_on            = [azurerm_storage_account.bosh]
-  storage_account_name  = azurerm_storage_account.bosh.name
+  storage_account_id    = azurerm_storage_account.bosh.id
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "stemcell" {
   name                  = "stemcell"
   depends_on            = [azurerm_storage_account.bosh]
-  storage_account_name  = azurerm_storage_account.bosh.name
+  storage_account_id    = azurerm_storage_account.bosh.id
   container_access_type = "blob"
 }
 

--- a/azure/ops-manager-subnets.tf
+++ b/azure/ops-manager-subnets.tf
@@ -3,7 +3,7 @@ resource "azurerm_subnet" "management" {
 
   resource_group_name  = azurerm_resource_group.platform.name
   virtual_network_name = azurerm_virtual_network.platform.name
-  address_prefixes     = [ var.management_subnet_cidr ]
+  address_prefixes     = [var.management_subnet_cidr]
 
 }
 
@@ -22,7 +22,7 @@ resource "azurerm_subnet" "services" {
 
   resource_group_name  = azurerm_resource_group.platform.name
   virtual_network_name = azurerm_virtual_network.platform.name
-  address_prefixes     = [ var.services_subnet_cidr ]
+  address_prefixes     = [var.services_subnet_cidr]
 
 }
 

--- a/azure/pas-dns.tf
+++ b/azure/pas-dns.tf
@@ -6,8 +6,8 @@ resource "azurerm_dns_a_record" "apps" {
   records             = [azurerm_public_ip.web-lb.ip_address]
 
   tags = merge(
-  var.tags,
-  { name = "*.apps.${var.environment_name}" },
+    var.tags,
+    { name = "*.apps.${var.environment_name}" },
   )
 }
 
@@ -19,8 +19,8 @@ resource "azurerm_dns_a_record" "sys" {
   records             = [azurerm_public_ip.web-lb.ip_address]
 
   tags = merge(
-  var.tags,
-  { name = "*.sys.${var.environment_name}" },
+    var.tags,
+    { name = "*.sys.${var.environment_name}" },
   )
 }
 
@@ -32,8 +32,8 @@ resource "azurerm_dns_a_record" "ssh" {
   records             = [azurerm_public_ip.diego-ssh-lb.ip_address]
 
   tags = merge(
-  var.tags,
-  { name = "ssh.sys.${var.environment_name}" },
+    var.tags,
+    { name = "ssh.sys.${var.environment_name}" },
   )
 }
 
@@ -45,8 +45,8 @@ resource "azurerm_dns_a_record" "mysql" {
   records             = [azurerm_lb.mysql.private_ip_address]
 
   tags = merge(
-  var.tags,
-  { name = "mysql.${var.environment_name}" },
+    var.tags,
+    { name = "mysql.${var.environment_name}" },
   )
 }
 
@@ -58,7 +58,7 @@ resource "azurerm_dns_a_record" "tcp" {
   records             = [azurerm_public_ip.tcp-lb.ip_address]
 
   tags = merge(
-  var.tags,
-  { name = "tcp.${var.environment_name}" },
+    var.tags,
+    { name = "tcp.${var.environment_name}" },
   )
 }

--- a/azure/pas-lbs.tf
+++ b/azure/pas-lbs.tf
@@ -36,20 +36,18 @@ resource "azurerm_lb_backend_address_pool" "web" {
 }
 
 resource "azurerm_lb_probe" "web-https" {
-  name                = "${var.environment_name}-web-lb-https-probe"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.web.id
-  protocol            = "TCP"
-  port                = 443
+  name            = "${var.environment_name}-web-lb-https-probe"
+  loadbalancer_id = azurerm_lb.web.id
+  protocol        = "Tcp"
+  port            = 443
 }
 
 resource "azurerm_lb_rule" "web-https" {
-  name                = "${var.environment_name}-web-https-rule"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.web.id
+  name            = "${var.environment_name}-web-https-rule"
+  loadbalancer_id = azurerm_lb.web.id
 
   frontend_ip_configuration_name = "frontendip"
-  protocol                       = "TCP"
+  protocol                       = "Tcp"
   frontend_port                  = 443
   backend_port                   = 443
   idle_timeout_in_minutes        = 30
@@ -59,20 +57,18 @@ resource "azurerm_lb_rule" "web-https" {
 }
 
 resource "azurerm_lb_probe" "web-http" {
-  name                = "${var.environment_name}-web-http-probe"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.web.id
-  protocol            = "TCP"
-  port                = 80
+  name            = "${var.environment_name}-web-http-probe"
+  loadbalancer_id = azurerm_lb.web.id
+  protocol        = "Tcp"
+  port            = 80
 }
 
 resource "azurerm_lb_rule" "web-http" {
-  name                = "${var.environment_name}-web-http-rule"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.web.id
+  name            = "${var.environment_name}-web-http-rule"
+  loadbalancer_id = azurerm_lb.web.id
 
   frontend_ip_configuration_name = "frontendip"
-  protocol                       = "TCP"
+  protocol                       = "Tcp"
   frontend_port                  = 80
   backend_port                   = 80
   idle_timeout_in_minutes        = 30
@@ -82,12 +78,11 @@ resource "azurerm_lb_rule" "web-http" {
 }
 
 resource "azurerm_lb_rule" "web-ntp" {
-  name                = "${var.environment_name}-web-ntp-rule"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.web.id
+  name            = "${var.environment_name}-web-ntp-rule"
+  loadbalancer_id = azurerm_lb.web.id
 
   frontend_ip_configuration_name = "frontendip"
-  protocol                       = "UDP"
+  protocol                       = "Udp"
   frontend_port                  = "123"
   backend_port                   = "123"
 
@@ -126,26 +121,24 @@ resource "azurerm_lb" "tcp" {
 }
 
 resource "azurerm_lb_backend_address_pool" "tcp" {
-  name                = "${var.environment_name}-tcp-backend-pool"
-  loadbalancer_id     = azurerm_lb.tcp.id
+  name            = "${var.environment_name}-tcp-backend-pool"
+  loadbalancer_id = azurerm_lb.tcp.id
 }
 
 resource "azurerm_lb_probe" "tcp" {
-  name                = "${var.environment_name}-tcp-probe"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.tcp.id
-  protocol            = "TCP"
-  port                = 80
+  name            = "${var.environment_name}-tcp-probe"
+  loadbalancer_id = azurerm_lb.tcp.id
+  protocol        = "Tcp"
+  port            = 80
 }
 
 resource "azurerm_lb_rule" "tcp-rule" {
-  count               = 5
-  name                = "${var.environment_name}-tcp-rule-${count.index + 1024}"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.tcp.id
+  count           = 5
+  name            = "${var.environment_name}-tcp-rule-${count.index + 1024}"
+  loadbalancer_id = azurerm_lb.tcp.id
 
   frontend_ip_configuration_name = "frontendip"
-  protocol                       = "TCP"
+  protocol                       = "Tcp"
   frontend_port                  = count.index + 1024
   backend_port                   = count.index + 1024
 
@@ -154,12 +147,11 @@ resource "azurerm_lb_rule" "tcp-rule" {
 }
 
 resource "azurerm_lb_rule" "tcp-ntp" {
-  name                = "${var.environment_name}-tcp-ntp-rule"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.tcp.id
+  name            = "${var.environment_name}-tcp-ntp-rule"
+  loadbalancer_id = azurerm_lb.tcp.id
 
   frontend_ip_configuration_name = "frontendip"
-  protocol                       = "UDP"
+  protocol                       = "Udp"
   frontend_port                  = "123"
   backend_port                   = "123"
 
@@ -185,25 +177,23 @@ resource "azurerm_lb" "mysql" {
 }
 
 resource "azurerm_lb_backend_address_pool" "mysql" {
-  name                = "${var.environment_name}-mysql-backend-pool"
-  loadbalancer_id     = azurerm_lb.mysql.id
+  name            = "${var.environment_name}-mysql-backend-pool"
+  loadbalancer_id = azurerm_lb.mysql.id
 }
 
 resource "azurerm_lb_probe" "mysql" {
-  name                = "${var.environment_name}-mysql-probe"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.mysql.id
-  protocol            = "TCP"
-  port                = 1936
+  name            = "${var.environment_name}-mysql-probe"
+  loadbalancer_id = azurerm_lb.mysql.id
+  protocol        = "Tcp"
+  port            = 1936
 }
 
 resource "azurerm_lb_rule" "mysql" {
-  name                = "${var.environment_name}-mysql-rule"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.mysql.id
+  name            = "${var.environment_name}-mysql-rule"
+  loadbalancer_id = azurerm_lb.mysql.id
 
   frontend_ip_configuration_name = "frontendip"
-  protocol                       = "TCP"
+  protocol                       = "Tcp"
   frontend_port                  = 3306
   backend_port                   = 3306
 
@@ -212,12 +202,11 @@ resource "azurerm_lb_rule" "mysql" {
 }
 
 resource "azurerm_lb_rule" "mysql-ntp" {
-  name                = "${var.environment_name}-mysql-ntp-rule"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.mysql.id
+  name            = "${var.environment_name}-mysql-ntp-rule"
+  loadbalancer_id = azurerm_lb.mysql.id
 
   frontend_ip_configuration_name = "frontendip"
-  protocol                       = "UDP"
+  protocol                       = "Udp"
   frontend_port                  = "123"
   backend_port                   = "123"
 
@@ -256,25 +245,23 @@ resource "azurerm_lb" "diego-ssh" {
 }
 
 resource "azurerm_lb_backend_address_pool" "diego-ssh" {
-  name                = "${var.environment_name}-diego-ssh-backend-pool"
-  loadbalancer_id     = azurerm_lb.diego-ssh.id
+  name            = "${var.environment_name}-diego-ssh-backend-pool"
+  loadbalancer_id = azurerm_lb.diego-ssh.id
 }
 
 resource "azurerm_lb_probe" "diego-ssh" {
-  name                = "${var.environment_name}-diego-ssh-probe"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.diego-ssh.id
-  protocol            = "TCP"
-  port                = 2222
+  name            = "${var.environment_name}-diego-ssh-probe"
+  loadbalancer_id = azurerm_lb.diego-ssh.id
+  protocol        = "Tcp"
+  port            = 2222
 }
 
 resource "azurerm_lb_rule" "diego-ssh" {
-  name                = "${var.environment_name}-diego-ssh-rule"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.diego-ssh.id
+  name            = "${var.environment_name}-diego-ssh-rule"
+  loadbalancer_id = azurerm_lb.diego-ssh.id
 
   frontend_ip_configuration_name = "frontendip"
-  protocol                       = "TCP"
+  protocol                       = "Tcp"
   frontend_port                  = 2222
   backend_port                   = 2222
 
@@ -283,12 +270,11 @@ resource "azurerm_lb_rule" "diego-ssh" {
 }
 
 resource "azurerm_lb_rule" "diego-ssh-ntp" {
-  name                = "${var.environment_name}-diego-ssh-ntp-rule"
-  resource_group_name = azurerm_resource_group.platform.name
-  loadbalancer_id     = azurerm_lb.diego-ssh.id
+  name            = "${var.environment_name}-diego-ssh-ntp-rule"
+  loadbalancer_id = azurerm_lb.diego-ssh.id
 
   frontend_ip_configuration_name = "frontendip"
-  protocol                       = "UDP"
+  protocol                       = "Udp"
   frontend_port                  = "123"
   backend_port                   = "123"
 

--- a/azure/pas-outputs.tf
+++ b/azure/pas-outputs.tf
@@ -1,31 +1,31 @@
 locals {
   stable_config_pas = {
-    pas_subnet_name = azurerm_subnet.pas.name
-    pas_subnet_id = azurerm_subnet.pas.id
-    pas_subnet_cidr = azurerm_subnet.pas.address_prefix
-    pas_subnet_gateway = cidrhost(azurerm_subnet.pas.address_prefix, 1)
-    pas_subnet_range = cidrhost(azurerm_subnet.pas.address_prefix, 10)
-    pas_buildpacks_container_name = azurerm_storage_container.pas-buildpacks.name
-    pas_packages_container_name = azurerm_storage_container.pas-packages.name
-    pas_droplets_container_name = azurerm_storage_container.pas-droplets.name
-    pas_resources_container_name = azurerm_storage_container.pas-resources.name
-    pas_storage_account_name = azurerm_storage_account.pas.name
+    pas_subnet_name                = azurerm_subnet.pas.name
+    pas_subnet_id                  = azurerm_subnet.pas.id
+    pas_subnet_cidr                = azurerm_subnet.pas.address_prefixes[0]
+    pas_subnet_gateway             = cidrhost(azurerm_subnet.pas.address_prefixes[0], 1)
+    pas_subnet_range               = cidrhost(azurerm_subnet.pas.address_prefixes[0], 10)
+    pas_buildpacks_container_name  = azurerm_storage_container.pas-buildpacks.name
+    pas_packages_container_name    = azurerm_storage_container.pas-packages.name
+    pas_droplets_container_name    = azurerm_storage_container.pas-droplets.name
+    pas_resources_container_name   = azurerm_storage_container.pas-resources.name
+    pas_storage_account_name       = azurerm_storage_account.pas.name
     pas_storage_account_access_key = azurerm_storage_account.pas.primary_access_key
 
-    web_lb_name = azurerm_lb.web.name
-    ssh_lb_name = azurerm_lb.diego-ssh.name
+    web_lb_name   = azurerm_lb.web.name
+    ssh_lb_name   = azurerm_lb.diego-ssh.name
     mysql_lb_name = azurerm_lb.mysql.name
-    tcp_lb_name = azurerm_lb.tcp.name
+    tcp_lb_name   = azurerm_lb.tcp.name
 
     apps_dns_domain = "${replace(azurerm_dns_a_record.apps.name, "*.", "")}.${azurerm_dns_a_record.apps.zone_name}"
-    sys_dns_domain = "${replace(azurerm_dns_a_record.sys.name, "*.", "")}.${azurerm_dns_a_record.sys.zone_name}"
-    ssh_dns = "${azurerm_dns_a_record.ssh.name}.${azurerm_dns_a_record.ssh.zone_name}"
-    tcp_dns = "${azurerm_dns_a_record.tcp.name}.${azurerm_dns_a_record.tcp.zone_name}"
-    mysql_dns = "${azurerm_dns_a_record.mysql.name}.${azurerm_dns_a_record.mysql.zone_name}"
+    sys_dns_domain  = "${replace(azurerm_dns_a_record.sys.name, "*.", "")}.${azurerm_dns_a_record.sys.zone_name}"
+    ssh_dns         = "${azurerm_dns_a_record.ssh.name}.${azurerm_dns_a_record.ssh.zone_name}"
+    tcp_dns         = "${azurerm_dns_a_record.tcp.name}.${azurerm_dns_a_record.tcp.zone_name}"
+    mysql_dns       = "${azurerm_dns_a_record.mysql.name}.${azurerm_dns_a_record.mysql.zone_name}"
   }
 }
 
 output "stable_config_pas" {
-  value = jsonencode(local.stable_config_pas)
+  value     = jsonencode(local.stable_config_pas)
   sensitive = true
 }

--- a/azure/pas-storage.tf
+++ b/azure/pas-storage.tf
@@ -5,20 +5,20 @@ resource "random_string" "pas" {
 }
 
 resource "azurerm_storage_account" "pas" {
-  name                      = random_string.pas.result
-  resource_group_name       = azurerm_resource_group.platform.name
-  location                  = var.location
-  account_tier              = "Standard"
-  account_kind              = "StorageV2"
-  account_replication_type  = "LRS"
-  enable_https_traffic_only = true
+  name                       = random_string.pas.result
+  resource_group_name        = azurerm_resource_group.platform.name
+  location                   = var.location
+  account_tier               = "Standard"
+  account_kind               = "StorageV2"
+  account_replication_type   = "LRS"
+  https_traffic_only_enabled = true
 
   tags = merge(
-  var.tags,
-  {
-    environment = var.environment_name
-    name        = random_string.pas.result
-  },
+    var.tags,
+    {
+      environment = var.environment_name
+      name        = random_string.pas.result
+    },
   )
 }
 
@@ -33,24 +33,24 @@ resource "azurerm_advanced_threat_protection" "pas" {
 
 resource "azurerm_storage_container" "pas-buildpacks" {
   name                  = "${var.environment_name}-pas-buildpacks"
-  storage_account_name  = azurerm_storage_account.pas.name
+  storage_account_id    = azurerm_storage_account.pas.id
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "pas-packages" {
   name                  = "${var.environment_name}-pas-packages"
-  storage_account_name  = azurerm_storage_account.pas.name
+  storage_account_id    = azurerm_storage_account.pas.id
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "pas-droplets" {
   name                  = "${var.environment_name}-pas-droplets"
-  storage_account_name  = azurerm_storage_account.pas.name
+  storage_account_id    = azurerm_storage_account.pas.id
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "pas-resources" {
   name                  = "${var.environment_name}-pas-resources"
-  storage_account_name  = azurerm_storage_account.pas.name
+  storage_account_id    = azurerm_storage_account.pas.id
   container_access_type = "private"
 }

--- a/azure/pas-subnets.tf
+++ b/azure/pas-subnets.tf
@@ -3,7 +3,7 @@ resource "azurerm_subnet" "pas" {
 
   resource_group_name  = azurerm_resource_group.platform.name
   virtual_network_name = azurerm_virtual_network.platform.name
-  address_prefixes    = [ var.pas_subnet_cidr ]
+  address_prefixes     = [var.pas_subnet_cidr]
 
 }
 

--- a/azure/pks-dns.tf
+++ b/azure/pks-dns.tf
@@ -6,7 +6,7 @@ resource "azurerm_dns_a_record" "pks" {
   records             = [azurerm_public_ip.pks-lb.ip_address]
 
   tags = merge(
-  var.tags,
-  { name = "pks.${var.environment_name}" },
+    var.tags,
+    { name = "pks.${var.environment_name}" },
   )
 }

--- a/azure/pks-lbs.tf
+++ b/azure/pks-lbs.tf
@@ -30,13 +30,12 @@ resource "azurerm_lb" "pks" {
 }
 
 resource "azurerm_lb_backend_address_pool" "pks-lb" {
-  name                = "${var.environment_name}-pks-backend-pool"
-  loadbalancer_id     = azurerm_lb.pks.id
+  name            = "${var.environment_name}-pks-backend-pool"
+  loadbalancer_id = azurerm_lb.pks.id
 }
 
 resource "azurerm_lb_probe" "pks-lb-uaa" {
   name                = "${var.environment_name}-pks-lb-uaa-health-probe"
-  resource_group_name = azurerm_resource_group.platform.name
   loadbalancer_id     = azurerm_lb.pks.id
   protocol            = "Tcp"
   interval_in_seconds = 5
@@ -46,7 +45,6 @@ resource "azurerm_lb_probe" "pks-lb-uaa" {
 
 resource "azurerm_lb_rule" "pks-lb-uaa" {
   name                           = "${var.environment_name}-pks-lb-uaa-rule"
-  resource_group_name            = azurerm_resource_group.platform.name
   loadbalancer_id                = azurerm_lb.pks.id
   protocol                       = "Tcp"
   frontend_port                  = 8443
@@ -58,7 +56,6 @@ resource "azurerm_lb_rule" "pks-lb-uaa" {
 
 resource "azurerm_lb_probe" "pks-lb-api" {
   name                = "${var.environment_name}-pks-lb-api-health-probe"
-  resource_group_name = azurerm_resource_group.platform.name
   loadbalancer_id     = azurerm_lb.pks.id
   protocol            = "Tcp"
   interval_in_seconds = 5
@@ -68,7 +65,6 @@ resource "azurerm_lb_probe" "pks-lb-api" {
 
 resource "azurerm_lb_rule" "pks-lb-api-rule" {
   name                           = "${var.environment_name}-pks-lb-api-rule"
-  resource_group_name            = azurerm_resource_group.platform.name
   loadbalancer_id                = azurerm_lb.pks.id
   protocol                       = "Tcp"
   frontend_port                  = 9021

--- a/azure/pks-outputs.tf
+++ b/azure/pks-outputs.tf
@@ -1,24 +1,24 @@
 locals {
   stable_config_pks = {
-    pks_as_name = azurerm_availability_set.pks_as.name
-    pks_lb_name = azurerm_lb.pks.name
-    pks_dns = "${azurerm_dns_a_record.pks.name}.${azurerm_dns_a_record.pks.zone_name}"
-    pks_subnet_name = azurerm_subnet.pks.name
-    pks_subnet_id = azurerm_subnet.pks.id
-    pks_subnet_cidr = azurerm_subnet.pks.address_prefix
-    pks_subnet_gateway = cidrhost(azurerm_subnet.pks.address_prefix, 1)
-    pks_subnet_range = cidrhost(azurerm_subnet.pks.address_prefix, 10)
-    pks_api_application_security_group_name = azurerm_application_security_group.pks-api.name
-    pks_api_network_security_group_name = azurerm_network_security_group.pks-api.name
-    pks_internal_network_security_group_name = azurerm_network_security_group.pks-internal.name
+    pks_as_name                                = azurerm_availability_set.pks_as.name
+    pks_lb_name                                = azurerm_lb.pks.name
+    pks_dns                                    = "${azurerm_dns_a_record.pks.name}.${azurerm_dns_a_record.pks.zone_name}"
+    pks_subnet_name                            = azurerm_subnet.pks.name
+    pks_subnet_id                              = azurerm_subnet.pks.id
+    pks_subnet_cidr                            = azurerm_subnet.pks.address_prefixes[0]
+    pks_subnet_gateway                         = cidrhost(azurerm_subnet.pks.address_prefixes[0], 1)
+    pks_subnet_range                           = cidrhost(azurerm_subnet.pks.address_prefixes[0], 10)
+    pks_api_application_security_group_name    = azurerm_application_security_group.pks-api.name
+    pks_api_network_security_group_name        = azurerm_network_security_group.pks-api.name
+    pks_internal_network_security_group_name   = azurerm_network_security_group.pks-internal.name
     pks_master_application_security_group_name = azurerm_application_security_group.pks-master.name
-    pks_master_network_security_group_name = azurerm_network_security_group.pks-master.name
-    pks_master_managed_identity = azurerm_user_assigned_identity.pks-master.name
-    pks_worker_managed_identity = azurerm_user_assigned_identity.pks-worker.name
+    pks_master_network_security_group_name     = azurerm_network_security_group.pks-master.name
+    pks_master_managed_identity                = azurerm_user_assigned_identity.pks-master.name
+    pks_worker_managed_identity                = azurerm_user_assigned_identity.pks-worker.name
   }
 }
 
 output "stable_config_pks" {
-  value = jsonencode(local.stable_config_pks)
+  value     = jsonencode(local.stable_config_pks)
   sensitive = true
 }

--- a/azure/pks-security-groups.tf
+++ b/azure/pks-security-groups.tf
@@ -16,8 +16,8 @@ resource "azurerm_network_security_group" "pks-master" {
   }
 
   tags = merge(
-  var.tags,
-  { name = "${var.environment_name}-pks-master-network-sg" },
+    var.tags,
+    { name = "${var.environment_name}-pks-master-network-sg" },
   )
 }
 
@@ -39,8 +39,8 @@ resource "azurerm_network_security_group" "pks-api" {
   }
 
   tags = merge(
-  var.tags,
-  { name = "${var.environment_name}-pks-api-network-sg" },
+    var.tags,
+    { name = "${var.environment_name}-pks-api-network-sg" },
   )
 }
 
@@ -62,8 +62,8 @@ resource "azurerm_network_security_group" "pks-internal" {
   }
 
   tags = merge(
-  var.tags,
-  { name = "${var.environment_name}-pks-internal-network-sg" },
+    var.tags,
+    { name = "${var.environment_name}-pks-internal-network-sg" },
   )
 }
 
@@ -73,8 +73,8 @@ resource "azurerm_application_security_group" "pks-master" {
   resource_group_name = azurerm_resource_group.platform.name
 
   tags = merge(
-  var.tags,
-  { name = "${var.environment_name}-pks-master-app-sg" },
+    var.tags,
+    { name = "${var.environment_name}-pks-master-app-sg" },
   )
 }
 
@@ -84,7 +84,7 @@ resource "azurerm_application_security_group" "pks-api" {
   resource_group_name = azurerm_resource_group.platform.name
 
   tags = merge(
-  var.tags,
-  { name = "${var.environment_name}-pks-api-app-sg" },
+    var.tags,
+    { name = "${var.environment_name}-pks-api-app-sg" },
   )
 }

--- a/azure/pks-subnets.tf
+++ b/azure/pks-subnets.tf
@@ -3,7 +3,7 @@ resource "azurerm_subnet" "pks" {
 
   resource_group_name  = azurerm_resource_group.platform.name
   virtual_network_name = azurerm_virtual_network.platform.name
-  address_prefixes     = [ var.pks_subnet_cidr ]
+  address_prefixes     = [var.pks_subnet_cidr]
 
 }
 

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      version = "~> 2.85.0"
+      source  = "hashicorp/azurerm"
+      version = "~> 4.52"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
- Moves from AzureRM provider v2 to v4, applying required changes to clear errors and warnings.
- I did this because I got an error from Azure when using the v2 provider, which did not occur with the v3 or v4 providers. The error initially looks like my service principle does not have the correct permissions, but upgrading the provider consistently fixes it. I would guess the newer providers use a different API. My guess would be that there was a change in behavior on the Azure backend - possibly a deprecation (the v2 provider is very old now), or possibly an error that will get corrected in time.
```
Error: building account: getting authenticated object ID: Error listing Service Principals: autorest.DetailedError{Original:(*azure.RequestError)(0xc001956090), PackageType:"graphrbac.ServicePrincipalsClient", Method:"List", StatusCode:403, Message:"Failure responding to request", ServiceError:[]uint8(nil), Response:(*http.Response)(0xc001956000)}
```
- I've tested `terraform apply`, and also tested installing OpsManager and TAS (PKS files were removed)
- `terraform fmt` was used to tidy up the output