### PR TITLE
Fix TCP target group name exceeding AWS 32-char limit

### DIFF
--- a/aws/pas-lbs.tf
+++ b/aws/pas-lbs.tf
@@ -109,7 +109,7 @@ resource "aws_lb_listener" "tcp" {
 }
 
 resource "aws_lb_target_group" "tcp" {
-  name     = "${var.environment_name}-tcp-tg-${1024 + count.index}"
+  name     = "${substr(var.environment_name, 0, 19)}-tcp-${1024 + count.index}"
   port     = 1024 + count.index
   protocol = "TCP"
   vpc_id   = aws_vpc.vpc.id


### PR DESCRIPTION
## Problem

The `aws_lb_target_group.tcp` resource currently names target groups as:

```
"${var.environment_name}-tcp-tg-${1024 + count.index}"
```

For environment names >= 21 characters (e.g. `twilight-paladin-6a43` at 21 chars), the generated name reaches 33+ characters, exceeding AWS's 32-character limit and causing `terraform apply` to fail:

```
Error: "name" cannot be longer than 32 characters
  with aws_lb_target_group.tcp[2],
  on pas-lbs.tf line 112
```

## Fix

Use Terraform's `substr()` to cap the prefix and drop the redundant `-tg` suffix (the resource type already identifies this as a target group):

```hcl
name = "${substr(var.environment_name, 0, 19)}-tcp-${1024 + count.index}"
```

Maximum length: 19 + 5 (`-tcp-`) + 4 (`1028`) = **28 chars**, safely under the 32-char limit for any environment name.
